### PR TITLE
Improve clippy compliance across parser and tests

### DIFF
--- a/cfg-derive/src/lib.rs
+++ b/cfg-derive/src/lib.rs
@@ -68,11 +68,11 @@ fn derive_config_struct(
             for rule in &field.validates {
                 if let ValidateRule::Regex { pattern, .. } = rule {
                     let key = pattern.to_token_stream().to_string();
-                    if !map.contains_key(&key) {
+                    map.entry(key).or_insert_with(|| {
                         let ident = quote::format_ident!("__CFG_REGEX_{}", idx);
                         idx += 1;
-                        map.insert(key, ident);
-                    }
+                        ident
+                    });
                 }
             }
         }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -796,8 +796,8 @@ mod test {
     fn configuration_refresh_tests() {
         let mut cfg = Configuration::new();
         // No loader registered, refresh should return false
-        assert_eq!(cfg.refresh_ref().unwrap(), false);
-        assert_eq!(cfg.refresh().unwrap(), false);
+        assert!(!cfg.refresh_ref().unwrap());
+        assert!(!cfg.refresh().unwrap());
     }
 
     #[test]

--- a/src/err.rs
+++ b/src/err.rs
@@ -210,14 +210,14 @@ mod tests {
 
     #[test]
     fn display_config_cause() {
-        let io_err = std::io::Error::new(std::io::ErrorKind::Other, "io");
+        let io_err = std::io::Error::other("io");
         let e = ConfigError::from_cause(io_err);
         assert_eq!(format!("{}", e), "Configuration error caused by: io");
     }
 
     #[test]
     fn config_error_from_converts_to_configcause() {
-        let io_err = std::io::Error::new(std::io::ErrorKind::Other, "io");
+        let io_err = std::io::Error::other("io");
         let ce = ConfigError::from_cause(io_err);
         match ce {
             ConfigError::ConfigCause(_) => {}

--- a/src/source/ini.rs
+++ b/src/source/ini.rs
@@ -24,7 +24,7 @@ impl ConfigSourceParser for Ini {
     type Adaptor = Ini;
 
     fn parse_source(c: &str) -> Result<Self::Adaptor, ConfigError> {
-        Ok(Self::load_from_str(c).map_err(ConfigError::from_cause)?)
+        Self::load_from_str(c).map_err(ConfigError::from_cause)
     }
 
     fn file_extensions() -> Vec<&'static str> {

--- a/src/source/json.rs
+++ b/src/source/json.rs
@@ -27,7 +27,7 @@ impl ConfigSourceAdaptor for Json {
 impl ConfigSourceParser for Json {
     type Adaptor = Json;
     fn parse_source(content: &str) -> Result<Self::Adaptor, ConfigError> {
-        Ok(json::parse(content).map_err(ConfigError::from_cause)?)
+        json::parse(content).map_err(ConfigError::from_cause)
     }
 
     fn file_extensions() -> Vec<&'static str> {

--- a/src/source/memory.rs
+++ b/src/source/memory.rs
@@ -365,7 +365,7 @@ mod tests {
             let mut builder = hs.prefixed();
             builder.set("s1", "abc");
             builder.set("i1", 123);
-            builder.set("f1", 3.14);
+            builder.set("f1", std::f64::consts::PI);
             builder.set("b1", true);
         }
         // String
@@ -390,8 +390,8 @@ mod tests {
         let mut key = cache.new_key();
         key.push("f1");
         match hs.get_value(&key) {
-            Some(ConfigValue::Float(f)) if (f - 3.14).abs() < 1e-6 => {}
-            _ => panic!("Expected Float(3.14)"),
+            Some(ConfigValue::Float(f)) if (f - std::f64::consts::PI).abs() < 1e-6 => {}
+            _ => panic!("Expected Float(PI)"),
         }
         // Bool
         let mut cache = crate::key::CacheString::new();

--- a/src/source/toml.rs
+++ b/src/source/toml.rs
@@ -24,7 +24,7 @@ impl ConfigSourceAdaptor for Toml {
 impl ConfigSourceParser for Toml {
     type Adaptor = Toml;
     fn parse_source(c: &str) -> Result<Self::Adaptor, ConfigError> {
-        Ok(toml::from_str::<Value>(c).map_err(ConfigError::from_cause)?)
+        toml::from_str::<Value>(c).map_err(ConfigError::from_cause)
     }
 
     fn file_extensions() -> Vec<&'static str> {

--- a/src/value.rs
+++ b/src/value.rs
@@ -859,10 +859,10 @@ mod test {
             _ => panic!("Expected Int variant"),
         }
 
-        let v1 = ConfigValue::Float(3.14);
+        let v1 = ConfigValue::Float(std::f64::consts::PI);
         let v2 = v1.clone_static();
         match v2 {
-            ConfigValue::Float(f) => assert!((f - 3.14).abs() < 1e-6),
+            ConfigValue::Float(f) => assert!((f - std::f64::consts::PI).abs() < 1e-6),
             _ => panic!("Expected Float variant"),
         }
 
@@ -954,26 +954,26 @@ mod test {
             &mut context.0.source.new_context(&mut context.1),
             ConfigValue::StrRef("no"),
         );
-        assert_eq!(v.unwrap(), false);
+        assert!(!v.unwrap());
 
         // Str true/false
         let v = <bool as FromValue>::from_value(
             &mut context.0.source.new_context(&mut context.1),
             ConfigValue::Str("yes".to_string()),
         );
-        assert_eq!(v.unwrap(), true);
+        assert!(v.unwrap());
         let v = <bool as FromValue>::from_value(
             &mut context.0.source.new_context(&mut context.1),
             ConfigValue::Str("false".to_string()),
         );
-        assert_eq!(v.unwrap(), false);
+        assert!(!v.unwrap());
 
         // Bool
         let v = <bool as FromValue>::from_value(
             &mut context.0.source.new_context(&mut context.1),
             ConfigValue::Bool(true),
         );
-        assert_eq!(v.unwrap(), true);
+        assert!(v.unwrap());
 
         // 非法类型
         let v = <bool as FromValue>::from_value(


### PR DESCRIPTION
### Motivation
- Reduce Clippy warnings and make parser/test code more idiomatic and maintainable by addressing small pattern issues flagged by static analysis.
- Replace approximate literals and awkward patterns in tests to improve accuracy and clarity of expectations.

### Description
- Use `BTreeMap::entry(...).or_insert_with(...)` in the regex derive code to avoid `contains_key` + `insert` and simplify map population in `cfg-derive/src/lib.rs`.
- Remove redundant `Ok(...?)` wrappers in parser implementations so TOML/JSON/INI parsing returns `map_err(...)` results directly in `src/source/toml.rs`, `src/source/json.rs`, and `src/source/ini.rs`.
- Replace literal `3.14` with `std::f64::consts::PI` in tests and update associated comparisons to refer to `PI` in `src/source/memory.rs` and `src/value.rs`.
- Make test assertions more idiomatic by replacing `assert_eq!(..., true/false)` with `assert!(...)` / `assert!(!...)`, and replace `std::io::Error::new(std::io::ErrorKind::Other, ...)` with `std::io::Error::other(...)` in `src/configuration.rs`, `src/value.rs`, and `src/err.rs`.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo clippy --all-targets --all-features` which completed successfully with no blocking errors.
- Ran `cargo test` which succeeded: unit tests `100 passed; 0 failed` and doctests completed (`11 passed; 0 failed; 6 ignored`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d7a616048832caa5ea5501756a525)