### PR TITLE
docs: bump README dependency examples to v1.0 and add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing to cfg-rs
+
+Thanks for your interest in improving `cfg-rs`! This document explains how to contribute code and documentation effectively.
+
+## Quick workflow
+
+1. Fork and create a feature branch.
+2. Make small, focused changes.
+3. Run formatting/lint/tests locally.
+4. Open a PR with motivation, design notes, and verification steps.
+
+## Local development
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --all-features
+cargo test
+```
+
+If your change touches docs examples, ensure doctests still pass via `cargo test`.
+
+## Pull request checklist
+
+Before opening a PR, please make sure:
+
+- [ ] The change is scoped and explained in the PR description.
+- [ ] Public behavior changes are documented in `README.md` and/or doc comments.
+- [ ] New APIs include at least one usage example.
+- [ ] Error messages are actionable and user-friendly.
+- [ ] `cargo fmt`, `cargo clippy`, and `cargo test` pass.
+
+## Documentation guidelines
+
+For an open-source crate, docs are part of the product. Prefer:
+
+- **Task-first writing**: start with "how to use" before internals.
+- **Copy-paste examples**: runnable snippets with realistic defaults.
+- **Feature clarity**: state required crate feature flags next to examples.
+- **Migration notes**: call out breaking changes and alternatives.
+- **Discoverability**: cross-link README, examples, and API docs.
+
+### Recommended structure for new docs
+
+When adding a new capability, include:
+
+1. What problem it solves.
+2. Minimal example.
+3. Common failure modes / gotchas.
+4. Advanced options.
+5. Links to source tests/examples.
+
+## Commit message suggestions
+
+Use short, descriptive messages, e.g.:
+
+- `docs: add feature flag matrix`
+- `feat: support custom validator path`
+- `fix: preserve source priority on refresh`
+
+## Reporting issues
+
+Please include:
+
+- Rust version (`rustc -V`)
+- `cfg-rs` version and enabled features
+- Minimal reproducible config/input
+- Expected vs actual behavior
+
+Thanks again for helping make `cfg-rs` better.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ If you are new to this crate, read in this order:
 - Placeholder expansion like `${cfg.key}`: see [ConfigValue](enum.ConfigValue.html#placeholder-expression)
 - Random values under the `rand` feature (e.g. `configuration.get::<u8>("random.u8")`)
 - Refreshable values via [RefValue](struct.RefValue.html) and refreshable [Configuration](struct.Configuration.html)
+- Field-level validation via `#[validate(...)]` rules (range, length, not_empty, custom, regex)
 - Pluggable sources with clear priority: see [register_source](struct.Configuration.html#method.register_source)[^priority]
 - No serde dependency
 
@@ -52,10 +53,11 @@ Built-in file parsers (enable via Cargo features):
 
 Other useful features:
 
+- `validate` (built-in): supports `#[validate(range)]`, `#[validate(length)]`, `#[validate(not_empty)]`, and `#[validate(custom = ...)]`
 - `rand`: random value provider (e.g. `random.u8`, `random.string`)
 - `log`: minimal logging integration for value parsing
 - `coarsetime`: coarse time helpers for time-related values
-- `regex`: regex validation support for `#[validate(regex = ...)]`
+- `regex`: enables `#[validate(regex = ...)]` validator
 
 Tip: in application crates, define your own feature aliases (e.g. `full-config = ["cfg-rs/full"]`) so downstream users can enable capabilities consistently.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ cfg-rs is a lightweight, flexible configuration loader for Rust applications. It
 
 See the [examples](https://github.com/leptonyu/cfg-rs/tree/main/examples) directory for end-to-end demos.
 
+## Documentation map
+
+If you are new to this crate, read in this order:
+
+1. **Quick start** in this README
+2. **Examples** for end-to-end usage patterns
+3. **docs.rs API reference** for type-level details
+4. **CONTRIBUTING.md** for contribution and documentation standards
+
+- Examples: <https://github.com/leptonyu/cfg-rs/tree/main/examples>
+- API docs: <https://docs.rs/cfg-rs>
+- Contributing guide: [CONTRIBUTING.md](CONTRIBUTING.md)
+
+
 ## Features
 
 - Single call to load typed config: see [Configuration::get](struct.Configuration.html#method.get)
@@ -29,10 +43,12 @@ See the [examples](https://github.com/leptonyu/cfg-rs/tree/main/examples) direct
 
 Built-in file parsers (enable via Cargo features):
 
-- `toml`: extensions `.toml`, `.tml`
-- `yaml`: extensions `.yaml`, `.yml`
-- `json`: extension `.json`
-- `ini`: extension `.ini`
+| Feature | File extensions | Notes |
+| --- | --- | --- |
+| `toml` | `.toml`, `.tml` | Typed values and nested tables |
+| `yaml` | `.yaml`, `.yml` | Friendly for hand-written configs |
+| `json` | `.json` | Good for generated or machine-edited config |
+| `ini` | `.ini` | Flat/simple legacy formats |
 
 Other useful features:
 
@@ -41,19 +57,21 @@ Other useful features:
 - `coarsetime`: coarse time helpers for time-related values
 - `regex`: regex validation support for `#[validate(regex = ...)]`
 
+Tip: in application crates, define your own feature aliases (e.g. `full-config = ["cfg-rs/full"]`) so downstream users can enable capabilities consistently.
+
 ## Installation
 
 Add to your Cargo.toml with the features you need:
 
 ```toml
 [dependencies]
-cfg-rs = { version = "^0.6", features = ["toml"] }
+cfg-rs = { version = "^1.0", features = ["toml"] }
 ```
 
 For a batteries-included setup, use the convenience feature set:
 
 ```toml
-cfg-rs = { version = "^0.6", features = ["full"] }
+cfg-rs = { version = "^1.0", features = ["full"] }
 ```
 
 ## Quick start
@@ -251,4 +269,14 @@ This crate supports Rust **1.85** and newer. Older Rust versions are not guarant
 - Docs.rs builds enable all features for a comprehensive reference
 
 
+## Open-source documentation improvement checklist
 
+If you maintain this project, these upgrades usually provide the biggest payoff:
+
+- Add a **versioned migration section** in release notes for each breaking/non-trivial change.
+- Keep a **"common recipes"** section (env + file layering, validation patterns, refresh loop).
+- Add **"troubleshooting"** for frequent errors (missing feature flags, key prefix mismatch, parse failures).
+- Keep examples aligned with latest API and feature naming.
+- Treat README + examples + doc comments as one documentation surface; update all three together in PRs.
+
+These habits improve first-run success for users and reduce repeated issue triage for maintainers.


### PR DESCRIPTION
### Motivation
- Ensure README dependency snippets show the current major crate version so users copy accurate `Cargo.toml` examples.
- Improve onboarding and contribution quality by adding a concise contribution guide and a documentation map in the README.

### Description
- Updated README dependency examples from `cfg-rs = { version = "^0.6" ... }` to `cfg-rs = { version = "^1.0" ... }` in both the minimal and `full` feature snippets.
- Added `CONTRIBUTING.md` with local development commands, a PR checklist, documentation guidelines, commit message suggestions, and issue reporting guidance.
- Expanded README with a documentation map, a feature/format table, tips for feature aliases, and an open-source documentation improvement checklist.
- Minor formatting adjustments to README surrounding the quick-start and feature sections to improve clarity.

### Testing
- Ran `cargo test -q` and the test suite completed successfully (unit tests passed: 100 passed; doctests and example tests also ran and passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d7a616048832caa5ea5501756a525)